### PR TITLE
fix: missing username in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           arguments: publish
           build-root-directory: sdk-dist/kotlin
         env:
-          USER: ${{ github.actor }}
+          USERNAME: ${{ github.actor }}
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: gradle/gradle-build-action@v2
         name: Building Kotlin Docs


### PR DESCRIPTION
Missing username in GitHub Action field. Previous is user not username